### PR TITLE
Remove post excerpts

### DIFF
--- a/insights.md
+++ b/insights.md
@@ -6,14 +6,14 @@ permalink: /insights/
 
 {% for post in site.posts %}
   <article class="post">
-  
-    <h3><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h3>
-
-    <div class="entry">
-        {{ post.excerpt }}
-    </div>
-
-      <a href="{{ site.baseurl }}{{ post.url }}" class="read-more">Read More</a>
-    </article>
+    <h3>
+      <a href="{{ site.baseurl }}{{ post.url }}">
+        {{ post.title }}
+      </a>
+    </h3>
+    <a href="{{ site.baseurl }}{{ post.url }}"
+       class="read-more">
+       Read More
+    </a>
+  </article>
  {% endfor %}
-


### PR DESCRIPTION
The `Insights` page was creating a list entry for each post in the `_posts` folder. The HTML that it was creating for each list entry contained an excerpt from each post, which defaults to the first paragraph of the post. This did wonky things and I think the excerpts should just be removed.


Before, the `Insights` page looked like this:

<img width="778" alt="Screen Shot 2025-06-02 at 10 42 24 PM" src="https://github.com/user-attachments/assets/a88a7a14-c8a4-404d-a601-313a6d43c5e1" />


After, it looks like this:

<img width="750" alt="Screen Shot 2025-06-02 at 10 40 42 PM" src="https://github.com/user-attachments/assets/140b290f-7d34-4d4e-8aef-70433adbc2bd" />
